### PR TITLE
Add docker compose and Playwright E2E script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.9'
+services:
+  app:
+    build:
+      context: ./app/backend
+      dockerfile: Dockerfile
+    ports:
+      - "50505:8000"
+    environment:
+      AZURE_STORAGE_ACCOUNT: test-storage-account
+      AZURE_STORAGE_CONTAINER: test-storage-container
+      AZURE_STORAGE_RESOURCE_GROUP: test-storage-rg
+      AZURE_SUBSCRIPTION_ID: test-storage-subid
+      ENABLE_LANGUAGE_PICKER: 'false'
+      USE_SPEECH_INPUT_BROWSER: 'false'
+      USE_SPEECH_OUTPUT_AZURE: 'false'
+      AZURE_SEARCH_INDEX: test-search-index
+      AZURE_SEARCH_SERVICE: test-search-service
+      AZURE_SPEECH_SERVICE_ID: test-id
+      AZURE_SPEECH_SERVICE_LOCATION: eastus
+      AZURE_OPENAI_SERVICE: test-openai-service
+      AZURE_OPENAI_CHATGPT_MODEL: gpt-4.1-mini
+      AZURE_OPENAI_EMB_MODEL_NAME: text-embedding-3-large
+      AZURE_OPENAI_EMB_DIMENSIONS: '3072'

--- a/tests/run_e2e.sh
+++ b/tests/run_e2e.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT="${SCRIPT_DIR}/.."
+cd "$REPO_ROOT"
+
+python -m pip install -r requirements-dev.txt
+npm --prefix app/frontend ci
+npm --prefix app/frontend run build
+python -m playwright install --with-deps
+pytest tests/e2e.py


### PR DESCRIPTION
## Summary
- add docker-compose config for running app locally
- introduce Playwright-based end-to-end test runner script

## Testing
- `SKIP=prettier python -m pre_commit run --files docker-compose.yml tests/run_e2e.sh`
- `pytest tests/e2e.py::test_home -q` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_68aa86d98184833399a7422192af324c