### PR TITLE
Add Azure mock mode tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,14 @@
+# ruff: noqa: E402
 import json
 import os
+import pathlib
+import sys
 from typing import IO, Any
 from unittest import mock
+
+ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 import aiohttp
 import azure.cognitiveservices.speech
@@ -29,15 +36,17 @@ from openai.types.create_embedding_response import Usage
 
 import app
 import core
-from core.authentication import AuthenticationHelper
+from app.backend.prepdocslib.strategy import SearchInfo  # noqa: E402
+from core.authentication import AuthenticationHelper  # noqa: E402
 
-from .mocks import (
+from .mocks import (  # noqa: E402
     MockAsyncPageIterator,
     MockAsyncSearchResultsIterator,
     MockAzureCredential,
     MockAzureCredentialExpired,
     MockBlobClient,
     MockResponse,
+    MockSearchClient,
     mock_computervision_response,
     mock_retrieval_response,
     mock_speak_text_cancelled,
@@ -53,6 +62,17 @@ MockSearchIndex = SearchIndex(
     ],
 )
 MockAgent = KnowledgeAgent(name="test", models=[], target_indexes=[], request_limits=[])
+
+
+@pytest.fixture(scope="session", autouse=True)
+def set_azure_test_mode():
+    os.environ.setdefault("AZURE_TEST_MODE", "mock")
+
+
+@pytest.fixture(autouse=True)
+def mock_azure_services(monkeypatch):
+    if os.getenv("AZURE_TEST_MODE") == "mock":
+        monkeypatch.setattr(SearchInfo, "create_search_client", lambda self: MockSearchClient())
 
 
 async def mock_search(self, *args, **kwargs):

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -159,6 +159,21 @@ class MockAsyncSearchResultsIterator:
         return self
 
 
+class MockSearchClient:
+    def __init__(self):
+        self.filter = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def search(self, *args, **kwargs):
+        self.filter = kwargs.get("filter")
+        return MockAsyncSearchResultsIterator(kwargs.get("search_text"), kwargs.get("vector_queries"))
+
+
 class MockResponse:
     def __init__(self, status, text=None, headers=None):
         self._text = text or ""

--- a/tests/test_azure_mock_mode.py
+++ b/tests/test_azure_mock_mode.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+from app.backend.prepdocslib.strategy import SearchInfo
+from tests.mocks import MockAzureCredential, MockSearchClient
+
+
+@pytest.mark.asyncio
+async def test_search_uses_mock_client():
+    assert os.getenv("AZURE_TEST_MODE") == "mock"
+    search_info = SearchInfo(
+        endpoint="https://example.search.windows.net",
+        credential=MockAzureCredential(),
+        index_name="test-index",
+    )
+    async with search_info.create_search_client() as client:
+        assert isinstance(client, MockSearchClient)
+        results = []
+        search_results = await client.search("interest rates")
+        async for page in search_results:
+            async for doc in page:
+                results.append(doc)
+    assert results and results[0]["sourcefile"] == "Financial Market Analysis Report 2023.pdf"


### PR DESCRIPTION
## Summary
- add MockSearchClient and autouse fixture to mock Azure services when AZURE_TEST_MODE=mock
- add test verifying search uses mocked Azure client

## Testing
- `pre-commit run --files tests/mocks.py tests/conftest.py tests/test_azure_mock_mode.py`
- `PYTHONPATH=. pytest tests/test_azure_mock_mode.py` *(fails: ModuleNotFoundError: No module named 'app.backend'; 'app' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_68aa840d085083338fbc98c42cc25946