### PR TITLE
feat: add auth protected components and fetch utilities

### DIFF
--- a/app/frontend/src/api/fetchWrappers.ts
+++ b/app/frontend/src/api/fetchWrappers.ts
@@ -1,0 +1,36 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
+
+async function request<T>(path: string, options: RequestInit, token?: string): Promise<T> {
+    const headers = new Headers(options.headers);
+    if (token) {
+        headers.set("Authorization", `Bearer ${token}`);
+    }
+    const response = await fetch(`${API_BASE_URL}${path}`, { ...options, headers });
+    if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+    }
+    if (response.status === 204) {
+        return undefined as T;
+    }
+    return (await response.json()) as T;
+}
+
+export async function getJson<T>(path: string, token?: string): Promise<T> {
+    return request<T>(path, { method: "GET" }, token);
+}
+
+export async function postJson<T, B>(path: string, body: B, token?: string): Promise<T> {
+    return request<T>(path, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body)
+    }, token);
+}
+
+export async function postForm<T>(path: string, form: FormData, token?: string): Promise<T> {
+    return request<T>(path, { method: "POST", body: form }, token);
+}
+
+export async function del<T>(path: string, token?: string): Promise<T> {
+    return request<T>(path, { method: "DELETE" }, token);
+}

--- a/app/frontend/src/api/index.ts
+++ b/app/frontend/src/api/index.ts
@@ -1,2 +1,3 @@
 export * from "./api";
 export * from "./models";
+export * from "./fetchWrappers";

--- a/app/frontend/src/components/DocumentUploader/DocumentUploader.tsx
+++ b/app/frontend/src/components/DocumentUploader/DocumentUploader.tsx
@@ -1,0 +1,37 @@
+import { useState, ChangeEvent } from "react";
+import { useMsal } from "@azure/msal-react";
+import { getToken } from "../../authConfig";
+import { postForm, SimpleAPIResponse } from "../../api";
+
+const DocumentUploader = () => {
+    const { instance } = useMsal();
+    const [file, setFile] = useState<File | null>(null);
+    const [message, setMessage] = useState<string>("");
+
+    const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setFile(e.target.files ? e.target.files[0] : null);
+    };
+
+    const upload = async () => {
+        if (!file) return;
+        const token = await getToken(instance);
+        const form = new FormData();
+        form.append("file", file);
+        try {
+            const res = await postForm<SimpleAPIResponse>("/upload", form, token);
+            setMessage(res.message ?? "Uploaded");
+        } catch (e: any) {
+            setMessage(e.message);
+        }
+    };
+
+    return (
+        <div>
+            <input type="file" onChange={onChange} />
+            <button onClick={upload} disabled={!file}>Upload</button>
+            {message && <p>{message}</p>}
+        </div>
+    );
+};
+
+export default DocumentUploader;

--- a/app/frontend/src/components/DocumentUploader/index.ts
+++ b/app/frontend/src/components/DocumentUploader/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./DocumentUploader";

--- a/app/frontend/src/components/ProgressTracker/ProgressTracker.tsx
+++ b/app/frontend/src/components/ProgressTracker/ProgressTracker.tsx
@@ -1,0 +1,9 @@
+interface ProgressTrackerProps {
+    progress: number; // value between 0 and 1
+}
+
+const ProgressTracker = ({ progress }: ProgressTrackerProps) => {
+    return <progress value={progress} max={1} />;
+};
+
+export default ProgressTracker;

--- a/app/frontend/src/components/ProgressTracker/index.ts
+++ b/app/frontend/src/components/ProgressTracker/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ProgressTracker";

--- a/app/frontend/src/components/QuestionFlow/QuestionFlow.tsx
+++ b/app/frontend/src/components/QuestionFlow/QuestionFlow.tsx
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+const QuestionFlow = () => {
+    const [step, setStep] = useState(0);
+    const next = () => setStep(s => s + 1);
+
+    return (
+        <div>
+            <p>Question Flow Step: {step}</p>
+            <button onClick={next}>Next</button>
+        </div>
+    );
+};
+
+export default QuestionFlow;

--- a/app/frontend/src/components/QuestionFlow/index.ts
+++ b/app/frontend/src/components/QuestionFlow/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./QuestionFlow";

--- a/app/frontend/src/components/ReportViewer/ReportViewer.tsx
+++ b/app/frontend/src/components/ReportViewer/ReportViewer.tsx
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import { useMsal } from "@azure/msal-react";
+import { getToken } from "../../authConfig";
+import { getJson } from "../../api";
+
+interface Report {
+    content: string;
+}
+
+const ReportViewer = () => {
+    const { instance } = useMsal();
+    const [report, setReport] = useState<Report | null>(null);
+
+    useEffect(() => {
+        const load = async () => {
+            const token = await getToken(instance);
+            try {
+                const data = await getJson<Report>("/report", token);
+                setReport(data);
+            } catch (e) {
+                console.error(e);
+            }
+        };
+        load();
+    }, [instance]);
+
+    return <pre>{report ? report.content : "No report"}</pre>;
+};
+
+export default ReportViewer;

--- a/app/frontend/src/components/ReportViewer/index.ts
+++ b/app/frontend/src/components/ReportViewer/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./ReportViewer";

--- a/app/frontend/src/components/RequireAuth/RequireAuth.tsx
+++ b/app/frontend/src/components/RequireAuth/RequireAuth.tsx
@@ -1,0 +1,28 @@
+import { ReactNode, useEffect } from "react";
+import { useMsal } from "@azure/msal-react";
+import { useLogin, checkLoggedIn } from "../../authConfig";
+
+interface RequireAuthProps {
+    children: ReactNode;
+}
+
+const RequireAuth = ({ children }: RequireAuthProps) => {
+    const { instance } = useMsal();
+
+    useEffect(() => {
+        if (!useLogin) {
+            return;
+        }
+        checkLoggedIn(instance).then(isLogged => {
+            if (!isLogged) {
+                instance.loginRedirect().catch(e => {
+                    console.error("loginRedirect failed", e);
+                });
+            }
+        });
+    }, [instance]);
+
+    return <>{children}</>;
+};
+
+export default RequireAuth;

--- a/app/frontend/src/components/RequireAuth/index.ts
+++ b/app/frontend/src/components/RequireAuth/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./RequireAuth";

--- a/app/frontend/src/components/SessionManager/SessionManager.tsx
+++ b/app/frontend/src/components/SessionManager/SessionManager.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useMsal } from "@azure/msal-react";
+import { getToken } from "../../authConfig";
+
+const SessionManager = () => {
+    const { instance } = useMsal();
+
+    useEffect(() => {
+        // Prime token retrieval to manage session state
+        getToken(instance).catch(err => {
+            console.error("Token retrieval failed", err);
+        });
+    }, [instance]);
+
+    return <div>Session Manager</div>;
+};
+
+export default SessionManager;

--- a/app/frontend/src/components/SessionManager/index.ts
+++ b/app/frontend/src/components/SessionManager/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SessionManager";

--- a/app/frontend/src/index.tsx
+++ b/app/frontend/src/index.tsx
@@ -11,6 +11,7 @@ import "./index.css";
 
 import Chat from "./pages/chat/Chat";
 import LayoutWrapper from "./layoutWrapper";
+import RequireAuth from "./components/RequireAuth";
 import i18next from "./i18n/config";
 import { msalConfig, useLogin } from "./authConfig";
 
@@ -23,15 +24,37 @@ const router = createHashRouter([
         children: [
             {
                 index: true,
-                element: <Chat />
+                element: (
+                    <RequireAuth>
+                        <Chat />
+                    </RequireAuth>
+                )
             },
             {
                 path: "qa",
-                lazy: () => import("./pages/ask/Ask")
+                lazy: async () => {
+                    const { Component: Ask } = await import("./pages/ask/Ask");
+                    return {
+                        element: (
+                            <RequireAuth>
+                                <Ask />
+                            </RequireAuth>
+                        )
+                    };
+                }
             },
             {
                 path: "*",
-                lazy: () => import("./pages/NoPage")
+                lazy: async () => {
+                    const { Component: NoPage } = await import("./pages/NoPage");
+                    return {
+                        element: (
+                            <RequireAuth>
+                                <NoPage />
+                            </RequireAuth>
+                        )
+                    };
+                }
             }
         ]
     }


### PR DESCRIPTION
## Summary
- add SessionManager, QuestionFlow, DocumentUploader, ProgressTracker, and ReportViewer components
- create RequireAuth route guard and wrap existing routes
- provide typed fetch helpers using VITE_API_BASE_URL and bearer tokens

## Testing
- `npm run build`
- `pytest` *(fails: ImportError while loading conftest '/workspace/azure-search-openai-demo/tests/conftest.py'. ModuleNotFoundError: No module named 'pytest_asyncio'; then after installing pytest-asyncio, tests produce 93 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8854abe188333bf6887180f7c4e0d