### PR TITLE
Normalize OCR text in PDF parser

### DIFF
--- a/app/backend/prepdocslib/pdfparser.py
+++ b/app/backend/prepdocslib/pdfparser.py
@@ -3,6 +3,7 @@ import io
 import logging
 from collections.abc import AsyncGenerator
 from enum import Enum
+import re
 from typing import IO, Union
 
 import pymupdf
@@ -26,6 +27,14 @@ from .parser import Parser
 logger = logging.getLogger("scripts")
 
 
+def normalize_text(data: str) -> str:
+    """Normalize OCR text by collapsing whitespace and newlines."""
+    output = data.replace("\r\n", "\n").replace("\r", "\n").replace("\u00A0", " ")
+    output = re.sub(r"\n{2,}", "\n", output)
+    output = re.sub(r"[^\S\n]{2,}", " ", output)
+    return output.strip()
+
+
 class LocalPdfParser(Parser):
     """
     Concrete parser backed by PyPDF that can parse PDFs into pages
@@ -39,7 +48,7 @@ class LocalPdfParser(Parser):
         pages = reader.pages
         offset = 0
         for page_num, p in enumerate(pages):
-            page_text = p.extract_text()
+            page_text = normalize_text(p.extract_text())
             yield Page(page_num=page_num, offset=offset, text=page_text)
             offset += len(page_text)
 
@@ -174,8 +183,7 @@ class DocumentAnalysisParser(Parser):
                             added_objects.add(mask_char)
                 # We remove these comments since they are not needed and skew the page numbers
                 page_text = page_text.replace("<!-- PageBreak -->", "")
-                # We remove excess newlines at the beginning and end of the page
-                page_text = page_text.strip()
+                page_text = normalize_text(page_text)
                 yield Page(page_num=page.page_number - 1, offset=offset, text=page_text)
                 offset += len(page_text)
 

--- a/tests/test_pdfparser.py
+++ b/tests/test_pdfparser.py
@@ -22,7 +22,7 @@ from azure.core.exceptions import HttpResponseError
 from PIL import Image, ImageChops
 
 from prepdocslib.mediadescriber import ContentUnderstandingDescriber
-from prepdocslib.pdfparser import DocumentAnalysisParser
+from prepdocslib.pdfparser import DocumentAnalysisParser, LocalPdfParser, normalize_text
 
 from .mocks import MockAzureCredential
 
@@ -252,7 +252,7 @@ async def test_parse_doc_with_tables(monkeypatch):
     assert pages[0].offset == 0
     assert (
         pages[0].text
-        == "# Simple HTML Table\n\n\n<figure><table><tr><th>Header 1</th><th>Header 2</th></tr><tr><td>Cell 1</td><td>Cell 2</td></tr><tr><td>Cell 3</td><td>Cell 4</td></tr></table></figure>"
+        == "# Simple HTML Table\n<figure><table><tr><th>Header 1</th><th>Header 2</th></tr><tr><td>Cell 1</td><td>Cell 2</td></tr><tr><td>Cell 3</td><td>Cell 4</td></tr></table></figure>"
     )
 
 
@@ -308,7 +308,7 @@ async def test_parse_doc_with_figures(monkeypatch):
     assert pages[0].offset == 0
     assert (
         pages[0].text
-        == "# Simple Figure\n\nThis text is before the figure and NOT part of it.\n\n\n<figure><figcaption>Figure 1<br>Pie chart</figcaption></figure>\n\n\nThis is text after the figure that's not part of it."
+        == "# Simple Figure\nThis text is before the figure and NOT part of it.\n<figure><figcaption>Figure 1<br>Pie chart</figcaption></figure>\nThis is text after the figure that's not part of it."
     )
 
 
@@ -370,3 +370,56 @@ async def test_parse_unsupportedformat(monkeypatch, caplog):
     assert pages[0].page_num == 0
     assert pages[0].offset == 0
     assert pages[0].text == "Page content"
+
+
+def test_normalize_text():
+    raw = "  This  has\n\n multiple\t\tspaces  "
+    assert normalize_text(raw) == "This has\n multiple spaces"
+
+
+@pytest.mark.asyncio
+async def test_local_pdfparser_normalization(monkeypatch):
+    class MockPage:
+        def extract_text(self):
+            return "  Hello   world\n\nSecond line  "
+
+    class MockReader:
+        pages = [MockPage()]
+
+    monkeypatch.setattr("prepdocslib.pdfparser.PdfReader", lambda content: MockReader())
+
+    parser = LocalPdfParser()
+    content = io.BytesIO(b"pdf")
+    content.name = "test.pdf"
+    pages = [page async for page in parser.parse(content)]
+    assert pages[0].text == "Hello world\nSecond line"
+
+
+@pytest.mark.asyncio
+async def test_documentanalysisparser_normalization(monkeypatch):
+    mock_poller = MagicMock()
+
+    async def mock_begin_analyze_document(self, model_id, analyze_request, **kwargs):
+        return mock_poller
+
+    raw = "  Hello   world\n\nSecond line  "
+
+    async def mock_poller_result():
+        return AnalyzeResult(
+            content=raw,
+            pages=[DocumentPage(page_number=1, spans=[DocumentSpan(offset=0, length=len(raw))])],
+            tables=[],
+            figures=[],
+        )
+
+    monkeypatch.setattr(DocumentIntelligenceClient, "begin_analyze_document", mock_begin_analyze_document)
+    monkeypatch.setattr(mock_poller, "result", mock_poller_result)
+
+    parser = DocumentAnalysisParser(
+        endpoint="https://example.com", credential=MockAzureCredential(), use_content_understanding=False
+    )
+    content = io.BytesIO(b"pdf bytes")
+    content.name = "test.pdf"
+
+    pages = [page async for page in parser.parse(content)]
+    assert pages[0].text == "Hello world\nSecond line"


### PR DESCRIPTION
## Summary
- Add normalization helper for OCR text and apply in PDF parsers
- Normalize OCR output before yielding pages
- Cover normalization behavior with unit tests

## Testing
- `pytest tests/test_pdfparser.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa831068948333b1d323ffe0938bb0