### PR TITLE
feat: add app mode settings and key vault loading

### DIFF
--- a/app/backend/main.py
+++ b/app/backend/main.py
@@ -1,12 +1,24 @@
 import os
 
+from dotenv import load_dotenv
+
 from app import create_app
 from load_azd_env import load_azd_env
+from settings import Settings, load_key_vault_secrets
+
+# Determine app mode early to load configuration sources
+app_mode = os.getenv("APP_MODE", "local").lower()
 
 # WEBSITE_HOSTNAME is always set by App Service, RUNNING_IN_PRODUCTION is set in main.bicep
 RUNNING_ON_AZURE = os.getenv("WEBSITE_HOSTNAME") is not None or os.getenv("RUNNING_IN_PRODUCTION") is not None
 
-if not RUNNING_ON_AZURE:
-    load_azd_env()
+if app_mode == "local":
+    load_dotenv()
+    if not RUNNING_ON_AZURE:
+        load_azd_env()
+elif app_mode in ("staging", "production"):
+    load_key_vault_secrets()
+
+settings = Settings()
 
 app = create_app()

--- a/app/backend/requirements.in
+++ b/app/backend/requirements.in
@@ -1,4 +1,5 @@
 azure-identity
+azure-keyvault-secrets
 quart
 quart-cors
 openai>=1.3.7

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -51,6 +51,8 @@ azure-identity==1.17.1
     # via
     #   -r requirements.in
     #   msgraph-sdk
+azure-keyvault-secrets==4.10.0
+    # via -r requirements.in
 azure-monitor-opentelemetry==1.6.13
     # via -r requirements.in
 azure-monitor-opentelemetry-exporter==1.0.0b40

--- a/app/backend/settings.py
+++ b/app/backend/settings.py
@@ -1,0 +1,34 @@
+import os
+from dataclasses import dataclass, field
+from typing import Literal, Optional
+
+
+@dataclass
+class Settings:
+    """Application settings loaded from environment variables."""
+
+    app_mode: Literal["local", "staging", "production"] = field(
+        default_factory=lambda: os.getenv("APP_MODE", "local").lower()
+    )
+    azure_key_vault_name: Optional[str] = field(
+        default_factory=lambda: os.getenv("AZURE_KEY_VAULT_NAME")
+    )
+
+
+def load_key_vault_secrets() -> None:
+    """Populate environment variables from Azure Key Vault secrets."""
+    key_vault_name = os.getenv("AZURE_KEY_VAULT_NAME")
+    if not key_vault_name:
+        return
+
+    from azure.identity import DefaultAzureCredential
+    from azure.keyvault.secrets import SecretClient
+
+    credential = DefaultAzureCredential()
+    client = SecretClient(
+        vault_url=f"https://{key_vault_name}.vault.azure.net", credential=credential
+    )
+    for secret in client.list_properties_of_secrets():
+        value = client.get_secret(secret.name).value
+        if value is not None:
+            os.environ.setdefault(secret.name, value)

--- a/app/backend/static/index.html
+++ b/app/backend/static/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Test Index</title></head>
+<body>Index</body>
+</html>


### PR DESCRIPTION
## Summary
- extend settings with `app_mode` supporting local, staging, and production
- load `.env` for local mode and pull secrets from Key Vault in staging/production
- add azure-keyvault-secrets dependency and include minimal static assets

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a883ed22bc8333bddc0c69c8b0c25b