### PR TITLE
Add Settings model and document env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,17 @@ You can only run a development server locally **after** having successfully run 
 It's also possible to enable hotloading or the VS Code debugger.
 See more tips in [the local development guide](docs/localdev.md).
 
+### Environment variables
+
+The backend reads configuration from environment variables via the `Settings` class
+(`app/backend/settings.py`).
+Set the following variables before running the app:
+
+- `AZURE_TENANT_ID` → `tenant_id`
+- `AZURE_CLIENT_ID` → `client_id`
+- `API_BASE_URL` → `api_base_url`
+- `AZURE_STORAGE_ENDPOINT` → `storage_endpoint`
+
 ## Using the app
 
 - In Azure: navigate to the Azure WebApp deployed by azd. The URL is printed out when azd completes (as "Endpoint"), or you can find it in the Azure portal.

--- a/app/backend/settings.py
+++ b/app/backend/settings.py
@@ -1,0 +1,11 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    tenant_id: str | None = Field(default=None, env="AZURE_TENANT_ID")
+    client_id: str | None = Field(default=None, env="AZURE_CLIENT_ID")
+    api_base_url: str | None = Field(default=None, env="API_BASE_URL")
+    storage_endpoint: str | None = Field(default=None, env="AZURE_STORAGE_ENDPOINT")


### PR DESCRIPTION
## Summary
- introduce `Settings` model to load core environment variables
- document required env vars and their mapping in README

## Testing
- `ruff check app/backend/settings.py`
- `pytest` *(fails: tests/test_app.py::test_index etc., 4 failed, 210 passed, 5 warnings, 93 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a883ef907c8333830e159b8e87d1a0