### PR TITLE
feat: add graph orchestrator

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -94,6 +94,7 @@ from core.authentication import AuthenticationHelper
 from core.sessionhelper import create_session_id
 from decorators import authenticated, authenticated_path
 from error import error_dict, error_response
+from orchestrator import build_default_orchestrator
 from prepdocs import (
     clean_key_if_exists,
     setup_embeddings_service,
@@ -108,6 +109,8 @@ bp = Blueprint("routes", __name__, static_folder="static")
 mimetypes.add_type("application/javascript", ".js")
 mimetypes.add_type("text/css", ".css")
 
+
+orchestrator = build_default_orchestrator()
 
 @bp.route("/")
 async def index():
@@ -186,11 +189,17 @@ async def ask(auth_claims: dict[str, Any]):
     context["auth_claims"] = auth_claims
     try:
         use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
-        approach: Approach
-        if use_gpt4v and CONFIG_ASK_VISION_APPROACH in current_app.config:
-            approach = cast(Approach, current_app.config[CONFIG_ASK_VISION_APPROACH])
+        route = orchestrator.route(request_json, default="data")
+        if route == "chat":
+            if use_gpt4v and CONFIG_CHAT_VISION_APPROACH in current_app.config:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_VISION_APPROACH])
+            else:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_APPROACH])
         else:
-            approach = cast(Approach, current_app.config[CONFIG_ASK_APPROACH])
+            if use_gpt4v and CONFIG_ASK_VISION_APPROACH in current_app.config:
+                approach = cast(Approach, current_app.config[CONFIG_ASK_VISION_APPROACH])
+            else:
+                approach = cast(Approach, current_app.config[CONFIG_ASK_APPROACH])
         r = await approach.run(
             request_json["messages"], context=context, session_state=request_json.get("session_state")
         )
@@ -225,11 +234,17 @@ async def chat(auth_claims: dict[str, Any]):
     context["auth_claims"] = auth_claims
     try:
         use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
-        approach: Approach
-        if use_gpt4v and CONFIG_CHAT_VISION_APPROACH in current_app.config:
-            approach = cast(Approach, current_app.config[CONFIG_CHAT_VISION_APPROACH])
+        route = orchestrator.route(request_json, default="chat")
+        if route == "data":
+            if use_gpt4v and CONFIG_ASK_VISION_APPROACH in current_app.config:
+                approach = cast(Approach, current_app.config[CONFIG_ASK_VISION_APPROACH])
+            else:
+                approach = cast(Approach, current_app.config[CONFIG_ASK_APPROACH])
         else:
-            approach = cast(Approach, current_app.config[CONFIG_CHAT_APPROACH])
+            if use_gpt4v and CONFIG_CHAT_VISION_APPROACH in current_app.config:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_VISION_APPROACH])
+            else:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_APPROACH])
 
         # If session state is provided, persists the session state,
         # else creates a new session_id depending on the chat history options enabled.
@@ -259,11 +274,17 @@ async def chat_stream(auth_claims: dict[str, Any]):
     context["auth_claims"] = auth_claims
     try:
         use_gpt4v = context.get("overrides", {}).get("use_gpt4v", False)
-        approach: Approach
-        if use_gpt4v and CONFIG_CHAT_VISION_APPROACH in current_app.config:
-            approach = cast(Approach, current_app.config[CONFIG_CHAT_VISION_APPROACH])
+        route = orchestrator.route(request_json, default="chat")
+        if route == "data":
+            if use_gpt4v and CONFIG_ASK_VISION_APPROACH in current_app.config:
+                approach = cast(Approach, current_app.config[CONFIG_ASK_VISION_APPROACH])
+            else:
+                approach = cast(Approach, current_app.config[CONFIG_ASK_APPROACH])
         else:
-            approach = cast(Approach, current_app.config[CONFIG_CHAT_APPROACH])
+            if use_gpt4v and CONFIG_CHAT_VISION_APPROACH in current_app.config:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_VISION_APPROACH])
+            else:
+                approach = cast(Approach, current_app.config[CONFIG_CHAT_APPROACH])
 
         # If session state is provided, persists the session state,
         # else creates a new session_id depending on the chat history options enabled.

--- a/app/backend/orchestrator.py
+++ b/app/backend/orchestrator.py
@@ -1,0 +1,67 @@
+"""Simple graph-based orchestrator for routing requests.
+
+The orchestrator holds a very small directed graph where the
+entry point decides which branch to follow based on predicates.
+This module is intentionally lightweight so it can be used during
+unit testing without external dependencies.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+Predicate = Callable[[dict[str, Any]], bool]
+
+
+@dataclass
+class GraphNode:
+    """A node in the routing graph."""
+
+    name: str
+    edges: Iterable[tuple[Predicate, GraphNode]] = field(default_factory=list)
+
+    def connect(self, condition: Predicate, node: GraphNode) -> None:
+        self.edges = tuple(list(self.edges) + [(condition, node)])
+
+
+class Orchestrator:
+    """Routes requests through a simple directed graph."""
+
+    def __init__(self, start: GraphNode):
+        self.start = start
+
+    def route(self, payload: dict[str, Any], default: str) -> str:
+        """Return the name of the next node based on predicates.
+
+        Parameters
+        ----------
+        payload: Dict[str, Any]
+            Request payload used to evaluate routing predicates.
+        default: str
+            Default node name returned when no predicate matches.
+        """
+        for condition, node in self.start.edges:
+            try:
+                if condition(payload):
+                    return node.name
+            except Exception:
+                # If a condition raises we ignore it and fall back to default.
+                continue
+        return default
+
+
+def build_default_orchestrator() -> Orchestrator:
+    """Create an orchestrator with chat/data routing logic.
+
+    The decision is based on ``payload["context"]["task"]``.  When the
+    value is ``"chat"`` the chat route is selected, when ``"data"`` the
+    data route is selected.  If the key is missing the caller provided
+    ``default`` value from :func:`Orchestrator.route` is used.
+    """
+    start = GraphNode("start")
+    chat = GraphNode("chat")
+    data = GraphNode("data")
+    start.connect(lambda m: m.get("context", {}).get("task") == "chat", chat)
+    start.connect(lambda m: m.get("context", {}).get("task") == "data", data)
+    return Orchestrator(start)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,19 @@
+from orchestrator import build_default_orchestrator
+
+
+def test_routes_to_data_when_context_specifies_data():
+    orch = build_default_orchestrator()
+    payload = {"context": {"task": "data"}}
+    assert orch.route(payload, default="chat") == "data"
+
+
+def test_routes_to_chat_by_default():
+    orch = build_default_orchestrator()
+    payload = {"context": {}}
+    assert orch.route(payload, default="chat") == "chat"
+
+
+def test_default_can_be_overridden():
+    orch = build_default_orchestrator()
+    payload: dict = {}
+    assert orch.route(payload, default="data") == "data"


### PR DESCRIPTION
## Summary
- add lightweight graph-based orchestrator for routing requests
- integrate orchestrator into ask, chat, and streaming chat endpoints
- cover routing behavior with new unit tests

## Testing
- `pytest tests/test_orchestrator.py tests/test_app.py::test_ask_request_must_be_json tests/test_app.py::test_chat_request_must_be_json -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa7bd52c2c833381055735a3c89f6b