### PR TITLE
Add environment-based settings and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ You can only run a development server locally **after** having successfully run 
 It's also possible to enable hotloading or the VS Code debugger.
 See more tips in [the local development guide](docs/localdev.md).
 
+## Configuration
+
+The backend reads several settings from environment variables. These map directly to the fields on the `Settings` class in
+`app/backend/settings.py`:
+
+| Environment variable | Field | Description |
+| --- | --- | --- |
+| `AZURE_TENANT_ID` | `tenant_id` | Azure Active Directory tenant identifier. |
+| `AZURE_CLIENT_ID` | `client_id` | Application client ID used for authentication. |
+| `API_BASE_URL` | `api_base_url` | Base URL for outbound API requests. |
+| `AZURE_STORAGE_ENDPOINT` | `storage_endpoint` | Endpoint for the Azure Storage account used by the app. |
+
+Ensure these variables are defined in your environment (or `.env` file) before running the application.
+
 ## Using the app
 
 - In Azure: navigate to the Azure WebApp deployed by azd. The URL is printed out when azd completes (as "Endpoint"), or you can find it in the Azure portal.

--- a/app/backend/requirements.in
+++ b/app/backend/requirements.in
@@ -27,6 +27,7 @@ PyMuPDF
 beautifulsoup4
 types-beautifulsoup4
 msgraph-sdk
+pydantic-settings
 python-dotenv
 prompty
 rich

--- a/app/backend/requirements.txt
+++ b/app/backend/requirements.txt
@@ -344,6 +344,8 @@ pydantic==2.8.2
     # via openai
 pydantic-core==2.20.1
     # via pydantic
+pydantic-settings==2.10.1
+    # via -r requirements.in
 pygments==2.18.0
     # via rich
 pyjwt[crypto]==2.10.1

--- a/app/backend/settings.py
+++ b/app/backend/settings.py
@@ -1,0 +1,14 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    tenant_id: str | None = Field(default=None, env="AZURE_TENANT_ID")
+    client_id: str | None = Field(default=None, env="AZURE_CLIENT_ID")
+    api_base_url: str | None = Field(default=None, env="API_BASE_URL")
+    storage_endpoint: str | None = Field(default=None, env="AZURE_STORAGE_ENDPOINT")
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- define `Settings` pydantic model to load key environment variables
- document mapping of environment variables to settings fields
- include pydantic-settings dependency

## Testing
- `pre-commit run --files README.md app/backend/settings.py app/backend/requirements.in app/backend/requirements.txt`
- `pytest` *(fails: assert 404 == 200 and many missing configuration errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a931d5e094833382108f451ec060eb