### PR TITLE
Add response scoring validator

### DIFF
--- a/app/backend/app.py
+++ b/app/backend/app.py
@@ -102,6 +102,7 @@ from prepdocs import (
 )
 from prepdocslib.filestrategy import UploadUserFileStrategy
 from prepdocslib.listfilestrategy import File
+from validator import evaluate_response
 
 bp = Blueprint("routes", __name__, static_folder="static")
 # Fix Windows registry issue with mimetypes
@@ -194,6 +195,8 @@ async def ask(auth_claims: dict[str, Any]):
         r = await approach.run(
             request_json["messages"], context=context, session_state=request_json.get("session_state")
         )
+        score = evaluate_response(r)
+        current_app.logger.debug("Response score: %s", score)
         return jsonify(r)
     except Exception as error:
         return error_response(error, "/ask")
@@ -244,6 +247,8 @@ async def chat(auth_claims: dict[str, Any]):
             context=context,
             session_state=session_state,
         )
+        score = evaluate_response(result)
+        current_app.logger.debug("Response score: %s", score)
         return jsonify(result)
     except Exception as error:
         return error_response(error, "/chat")

--- a/app/backend/validator.py
+++ b/app/backend/validator.py
@@ -1,0 +1,40 @@
+"""Simple response validator to compute a score for responses.
+
+This module provides a basic ``evaluate_response`` function which
+assigns a score between 0.0 and 1.0 based on heuristics about the
+returned answer.  The scorer is intentionally lightweight so it can
+serve as an example for how responses might be evaluated.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def evaluate_response(response: dict[str, Any]) -> float:
+    """Evaluate a response and return a score between 0.0 and 1.0.
+
+    Scoring rules:
+    * If the response is missing an ``answer`` field or the answer is
+      empty, return ``0.0``.
+    * If the answer contains "i don't know" (case insensitive), return
+      ``0.0``.
+    * If the answer has fewer than 20 words, return ``0.5``.
+    * Otherwise, return ``1.0``.
+
+    The heuristics are intentionally simple to keep the module
+    lightweight; they can be extended with additional logic as needed.
+    """
+
+    answer = str(response.get("answer", "")).strip()
+    if not answer:
+        return 0.0
+
+    lowered = answer.lower()
+    if "i don't know" in lowered or "i do not know" in lowered:
+        return 0.0
+
+    word_count = len(answer.split())
+    if word_count < 20:
+        return 0.5
+
+    return 1.0

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "app" / "backend"))
+from validator import evaluate_response
+
+
+def test_missing_answer():
+    assert evaluate_response({}) == 0.0
+
+
+def test_unknown_answer():
+    assert evaluate_response({"answer": "I don't know"}) == 0.0
+
+
+def test_short_answer():
+    assert evaluate_response({"answer": "Yes"}) == 0.5
+
+
+def test_long_answer():
+    long_text = "word " * 20
+    assert evaluate_response({"answer": long_text.strip()}) == 1.0


### PR DESCRIPTION
## Summary
- add simple heuristic-based response validator
- log validator scores in ask and chat endpoints
- cover validator scenarios with unit tests

## Testing
- `pytest tests/test_validator.py`
- `pytest tests/test_validator.py tests/test_app.py::test_ask_rtr_text tests/test_app.py::test_chat_text -q` *(fails: fixture 'snapshot' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa7fb9175c833387da02c760c4598e